### PR TITLE
Support for filepaths in pdf save, i.e., given filename includes a direc...

### DIFF
--- a/src/TikzPictures.jl
+++ b/src/TikzPictures.jl
@@ -160,10 +160,14 @@ function save(f::PDF, td::TikzDocument)
     else
       success(`lualatex $filename`)
     end
+
+    dir_name,base_name = splitdir(filename)
+    mv("$(base_name).pdf","$filename.pdf")
+
     if tikzDeleteIntermediate()
       rm("$filename.tex")
-      rm("$filename.aux")
-      rm("$filename.log")
+      rm("$(base_name).aux")
+      rm("$(base_name).log")
     end
   catch
     println("Error saving as PDF.")


### PR DESCRIPTION
...tory.

Behavior: will place pdf in the same directory as tex source, and removes intermediate files in working directory.  Previously, including a directory in filename would cause exception in removing intermediate files.