### PR TITLE
Run LaTeX twice if necessary

### DIFF
--- a/src/TikzPictures.jl
+++ b/src/TikzPictures.jl
@@ -188,16 +188,20 @@ function save(f::PDF, tp::TikzPicture)
         latexCommand = `$(tikzCommand()) --output-directory=$(foldername) $(f.filename)`
     end
     latexSuccess = success(latexCommand)
+    log = readstring("$(f.filename).log")
 
     if !latexSuccess
-        s = readstring("$(f.filename).log")
-        if !standaloneWorkaround() && contains(s, "\\sa@placebox ->\\newpage \\global \\pdfpagewidth")
+        if !standaloneWorkaround() && contains(log, "\\sa@placebox ->\\newpage \\global \\pdfpagewidth")
             standaloneWorkaround(true)
             save(f, tp)
             return
         end
-        latexerrormsg(s)
+        latexerrormsg(log)
         error("LaTeX error")
+    end
+
+    if contains(log, "LaTeX Warning: Label(s)")
+        success(latexCommand)
     end
 
     try


### PR DESCRIPTION
When using TikZ's `remember picture` option, it is sometimes necessary to run LaTeX twice to get correctly rendered pictures. (See Sec 17.13 of the TikZ manual for discussion.)