### PR TITLE
functionality to save `TikzPicture` as `.tikz` file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ tp = TikzPicture("\\draw (0,0) -- (10,10);\n\\draw (10,0) -- (0,10);\n\\node at 
 save(PDF("test"), tp)
 save(SVG("test"), tp)
 save(TEX("test"), tp)
+save(TIKZ("test"), tp)
 ```
 
 As you can see above, you have to escape backslashes and dollar signs in LaTeX. To simplify things, this package provides the LaTeXString type, which can be constructed via L"...." without escaping backslashes or dollar signs.


### PR DESCRIPTION
As a convenience method I would like to be able to save a single  `TikzPicture` as `.tikz` file. This would also enable me to uplift this possibility to the `PFGPlots` package.

I added this functionality and tested it by running
```julia
using TikzPictures
tp = TikzPicture("\\draw (0,0) -- (10,10);\n\\draw (10,0) -- (0,10);\n\\node at (5,5) {tikz \$\\sqrt{\\pi}\$};", options="scale=0.25", preamble="")
save(PDF("test"), tp)
save(SVG("test"), tp)
save(TEX("test"), tp)
save(TIKZ("test"), tp)
```