### PR TITLE
Fix deprecation warnings in Julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: julia
 sudo: required
 dist: trusty
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.6
 LaTeXStrings
 Compat 0.8.0

--- a/src/TikzPictures.jl
+++ b/src/TikzPictures.jl
@@ -77,7 +77,7 @@ function removeExtension(filename::AbstractString, extension::AbstractString)
     end
 end
 
-abstract SaveType
+abstract type SaveType end
 
 type PDF <: SaveType
     filename::AbstractString


### PR DESCRIPTION
`abstract [Type]` is deprecated starting with Julia 0.6.

`abstract type [Type] end` ist the new syntax.