### PR TITLE
loosen LaTeXStrings requirement to 0.2.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-LaTeXStrings 0.2.1
+LaTeXStrings 0.2


### PR DESCRIPTION
seems to pass tests - most users will upgrade to 0.2.1, but any reason to disallow 0.2.0?